### PR TITLE
Update debug mode copy

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -92,11 +92,19 @@ If everything went well, the widget should now display in a the dashboard.
 
 ## Using debug Mode
 
-![dev_mode1](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/yAu6LyoN/3ee9c354-00a6-4789-8a62-42abcac4500f.png?source=viewer&v=0eaa32e5d1121d0261332af776a89f9b)
-
 With debug mode, every widget will have a toolbar to make your DX better. For example, it allows you to refresh the widget you’re developing without refreshing the whole dashboard.
 
 ![dev_mode2](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/jkuen4y2/6c92f76c-5540-47fe-9c84-74a3676f5c1e.png?source=viewer&v=97ec2c27cb0b98c69ce09d5a3a5d7a6c)
+
+## Enabling debug mode
+
+1. Open https://app.datadoghq.com/apps, and click on "Manage Apps"
+
+![arrow pointing to the manage apps button](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/E0uj6wxE/dcbd8453-dac8-4ef2-9fb6-75ba1b17d698.jpg?source=viewer&v=b3760a3b7434e26cb69562f11dc78598)
+
+2. Enable debug mode for any apps you'd like
+
+![arrow pointing to debug button](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/lluoQPLE/6f8fa34d-3b5f-48d2-9d0a-fe0a00d2e9bd.jpg?v=53420b9f63222ec5df10be1339f2d7e1)
 
 ## I want to publish my app now !
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -90,11 +90,11 @@ If everything went well, the widget should now display in a the dashboard.
 
 ✅ Tip: Try modifying the content of your code and see the widget change in the dashboard.
 
-## Using developer Mode
+## Using debug Mode
 
 ![dev_mode1](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/yAu6LyoN/3ee9c354-00a6-4789-8a62-42abcac4500f.png?source=viewer&v=0eaa32e5d1121d0261332af776a89f9b)
 
-With developer mode, every widget will have a toolbar to make your DX better. For example, it allows you to refresh the widget you’re developing without refreshing the whole dashboard.
+With debug mode, every widget will have a toolbar to make your DX better. For example, it allows you to refresh the widget you’re developing without refreshing the whole dashboard.
 
 ![dev_mode2](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/jkuen4y2/6c92f76c-5540-47fe-9c84-74a3676f5c1e.png?source=viewer&v=97ec2c27cb0b98c69ce09d5a3a5d7a6c)
 


### PR DESCRIPTION
We updated the copy of this to be "debug" instead of "developer." We're updating the getting started to reflect that as well.

Added an "Enabling debug mode" section. Does that make sense?